### PR TITLE
Disable cpplint newline check

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,4 @@
 filter=-build/include_order
 filter=-whitespace/comments
+filter=-whitespace/newline
 exclude_files=build/*


### PR DESCRIPTION
bug fix the problem of inconsistent newline for else statement between cpplint and clangformat. Disable cpplint newline check.